### PR TITLE
Fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ networkInterface.with_depends_on([publicIp, vnet])
 
 # Create a parameter for the VM password and add it to the template
 vm_password_param = ARMParameter('vmPassword',
-                                 template=template,
                                  type='secureString',
                                  description='The password for the VM access. User is "adminuser"')
+template.add_parameter(vm_password_param)
 
 # Create the Virtual Machince object 
 vm = VirtualMachine('myvm',


### PR DESCRIPTION
The code tries to add a parameter to a template directly from the constructor. However this parameter ends up as a resource instead because the constructor calls `template.add_resource()` instead of `template.add_parameter()`. I end up with a template that looks like:

```
$schema: http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json
contentVersion: 1.0.0.0
resources:
  - metadata:
      description: The password for the VM access. User is "adminuser"
    type: secureString
```

I think upstream has a new `add_to_template()` method under `Parameter` and `BaseAWSObject` that calls the right `add_X()` method.