### PR TITLE
Fix example's with_depends_on()

### DIFF
--- a/ionosphere/base.py
+++ b/ionosphere/base.py
@@ -218,8 +218,7 @@ class ARMObject(AWSObject):
 
     def _add_dependency(self, dependency):
         if isinstance(dependency, ARMObject):
-            if self.template and self.template == dependency.template:
-                return dependency.Ref()
+            return dependency.Ref()
         elif isinstance(dependency, str):
             return dependency
         else:


### PR DESCRIPTION
The example uses `with_depends_on()` a few times and none of those uses do anything. That's because the code tests if the two objects have a template and it's the same template. The example doesn't initially set the template so this test fails silently and the dependencies are not added.

I'm not sure why the test was there in the first place. But if there is a good reason for it, I propose supporting no equality when no templates are defined. It should also raise an exception when the templates don't match instead of silently ignoring the dependency.